### PR TITLE
Import bookings from email body

### DIFF
--- a/rentals/templates/rentals/bookings_list.html
+++ b/rentals/templates/rentals/bookings_list.html
@@ -49,14 +49,11 @@
     <table>
       <thead>
         <tr>
-          <th>#</th>
-          <th>Δημιουργήθηκε</th>
+          <th>Ημερομηνίες</th>
           <th>Πελάτης</th>
           <th>Κατηγορία</th>
-          <th>Από</th>
-          <th>Έως</th>
-          <th>Ημέρες</th>
-          <th>Σύνολο</th>
+          <th>Κωδικός</th>
+          <th>Τηλέφωνο</th>
           <th>Status</th>
           <th>Ενέργειες</th>
         </tr>
@@ -64,14 +61,15 @@
       <tbody>
         {% for b in bookings %}
         <tr>
-          <td>{{ b.id }}</td>
-          <td>{{ b.created_at|date:"d-m-Y H:i" }}</td>
+          <td>
+            {% if b.start_date %}{{ b.start_date|date:"d-m-Y" }}{% else %}—{% endif %}
+            –
+            {% if b.end_date %}{{ b.end_date|date:"d-m-Y" }}{% else %}—{% endif %}
+          </td>
           <td>{{ b.customer_name|default:"—" }}</td>
           <td>{{ b.requested_category|default:"—" }}</td>
-          <td>{% if b.start_date %}{{ b.start_date|date:"d-m-Y" }}{% else %}—{% endif %}</td>
-          <td>{% if b.end_date %}{{ b.end_date|date:"d-m-Y" }}{% else %}—{% endif %}</td>
-          <td>{{ b.days }}</td>
-          <td>{% if b.total_price %}€{{ b.total_price }}{% else %}—{% endif %}</td>
+          <td>{{ b.booking_code|default:"—" }}</td>
+          <td>{{ b.customer_phone|default:"—" }}</td>
           <td><span class="badge b-{{ b.status }}">{{ b.status }}</span></td>
           <td>
             <div class="actions">
@@ -105,7 +103,7 @@
           </td>
         </tr>
         {% empty %}
-        <tr><td colspan="10" class="empty">Δεν υπάρχουν κρατήσεις.</td></tr>
+        <tr><td colspan="7" class="empty">Δεν υπάρχουν κρατήσεις.</td></tr>
         {% endfor %}
       </tbody>
     </table>

--- a/rentals/tests.py
+++ b/rentals/tests.py
@@ -7,6 +7,7 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from .models import Company, Booking
+from .utils_email import parse_booking_text
 
 
 class PasswordResetFlowTests(TestCase):
@@ -73,3 +74,20 @@ class BookingViewsTests(TestCase):
         self.assertRedirects(resp, reverse('rentals:bookings_list'))
         self.booking.refresh_from_db()
         self.assertEqual(self.booking.status, 'active')
+
+
+class EmailParsingTests(TestCase):
+    def test_parse_booking_text_from_body(self):
+        sample = (
+            "Name: Luciano Pasquali\n"
+            "Phone Number: 2101234567\n"
+            "Vehicle Class: ECMD\n"
+            "Pick up Location: Heraklion\nDate: 18/08/2025 14:00\n"
+            "Return Location: Heraklion\nDate: 29/08/2025 10:30\n"
+        )
+        data = parse_booking_text(sample)
+        self.assertEqual(data["customer_name"], "Luciano Pasquali")
+        self.assertEqual(data["customer_phone"], "2101234567")
+        self.assertEqual(data["requested_category"], "ecmd")
+        self.assertEqual(str(data["start_date"]), "2025-08-18")
+        self.assertEqual(str(data["end_date"]), "2025-08-29")


### PR DESCRIPTION
## Summary
- parse phone number, vehicle class, dates and booking code from email body text
- fall back to email body when no PDF attachment is found
- test parsing of booking data from email body

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a20949c908832a86cddcafe378b5f0